### PR TITLE
Fixed broken setup due to trying to read missing file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from distutils.core import setup
 from crpapi import __version__,__license__,__doc__
 
 license_text = open('LICENSE').read()
-long_description = open('README.rst').read()
 
 setup(name="python-crpapi",
       version=__version__,


### PR DESCRIPTION
Recieving the following error when trying to rum setup:

Traceback (most recent call last):
  File "lib/python-crpapi/setup.py", line 5, in <module>
  long_description = open('README.rst').read()
  IOError: [Errno 2] No such file or directory: 'README.rst'

Fixing by removing trying to read the README.rst file.
