### PR TITLE
fix setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 from crpapi import __version__,__license__,__doc__
 
 license_text = open('LICENSE').read()
-long_description = open('README.rst').read()
+long_description = open('README.md').read()
 
 setup(name="python-crpapi",
       version=__version__,


### PR DESCRIPTION
fixes the setup script from crashing when looking for README.rst which has been renamed to README.md
