### PR TITLE
Fix broken crpapi.py

### DIFF
--- a/crpapi.py
+++ b/crpapi.py
@@ -1,10 +1,10 @@
 """ 
-	Python library for interacting with the CRP API.
+    Python library for interacting with the CRP API.
 
     The CRP API (http://www.opensecrets.org/action/api_doc.php) provides campaign 
-	finance and other data from the Center for Responsive Politics.
+    finance and other data from the Center for Responsive Politics.
 
-	See README.rst for methods and usage
+    See README.rst for methods and usage
 """
 
 __author__ = "James Turk (jturk@sunlightfoundation.com)"
@@ -37,11 +37,14 @@ class CRP(object):
         if CRP.apikey is None:
             raise CRPApiError('Missing CRP apikey')
 
-        url = 'http://api.opensecrets.org/?method=%s&output=json&apikey=%s&%s' % \
+        url = 'http://www.opensecrets.org/api/?method=%s&output=json&apikey=%s&%s' % \
               (func, CRP.apikey, urllib.urlencode(params))
-        
+
+        headers = { 'User-Agent' : 'Mozilla/5.0' }
+        req = urllib2.Request(url, None, headers)        
+
         try:
-            response = urllib2.urlopen(url).read()
+            response = urllib2.urlopen(req).read()
             return json.loads(response)['response']
         except urllib2.HTTPError, e:
             raise CRPApiError(e.read())

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 from crpapi import __version__,__license__,__doc__
 
 license_text = open('LICENSE').read()
-long_description = open('README.rst').read()
+long_description = open('README.md').read()
 
 setup(name="python-crpapi",
       version=__version__,


### PR DESCRIPTION
Fix two problems:
1. setup.py was trying to load a nonexistant readme file. Changed it to
point to readme.md.
2. crpapi.py had a wrong URL for the API, and also wasn't setting
headers in the urllib2 request. Both these issues prevented API calls
from working.
